### PR TITLE
chore: refactor catalog and add snowflake tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@ build/
 target/
 build_script.spec
 .test_artifacts
+*.pyc
+.coverage
+coverage.xml
+metaframe_databuilder.egg-info/

--- a/metaframe/engine/presto_engine.py
+++ b/metaframe/engine/presto_engine.py
@@ -20,12 +20,12 @@ class PrestoAlchemyEngine(PrestoCommandsMixin, SQLAlchemyEngine):
     """
 
     CONN_STRING_KEY = 'conn_string'
-    DEFAULT_CLUSTER_NAME_KEY = 'default_cluster_name'
+    DEFAULT_CATALOG_NAME_KEY = 'default_catalog_name'
     DATABASE_KEY = 'database'
 
     DEFAULT_CONFIG = ConfigFactory.from_dict({
         CONN_STRING_KEY: None,
-        DEFAULT_CLUSTER_NAME_KEY: '<default>',  # if no cluster name is provided.
+        DEFAULT_CATALOG_NAME_KEY: '<default>',  # if no catalog name is provided.
         DATABASE_KEY: 'presto',
     })
 
@@ -36,8 +36,8 @@ class PrestoAlchemyEngine(PrestoCommandsMixin, SQLAlchemyEngine):
         })
         super().init(sql_alchemy_conf)
         self.conf = conf.with_fallback(PrestoAlchemyEngine.DEFAULT_CONFIG)
-        self._default_cluster_name = \
-            self.conf.get_string(PrestoAlchemyEngine.DEFAULT_CLUSTER_NAME_KEY)
+        self._default_catalog_name = \
+            self.conf.get_string(PrestoAlchemyEngine.DEFAULT_CATALOG_NAME_KEY)
         self._database = self.conf.get_string(PrestoAlchemyEngine.DATABASE_KEY)
         self._extract_iter = None
 
@@ -52,12 +52,12 @@ class PrestoEngine(PrestoCommandsMixin, SQLAlchemyEngine):
     """
 
     CONN_STRING_KEY = 'conn_string'
-    DEFAULT_CLUSTER_NAME_KEY = 'default_cluster_name'
+    DEFAULT_CATALOG_NAME_KEY = 'default_catalog_name'
     DATABASE_KEY = 'database'
 
     DEFAULT_CONFIG = ConfigFactory.from_dict({
         CONN_STRING_KEY: None,
-        DEFAULT_CLUSTER_NAME_KEY: '<default>',  # if no cluster name is provided.
+        DEFAULT_CATALOG_NAME_KEY: '<default>',  # if no catalog name is provided.
         DATABASE_KEY: 'presto',
     })
 
@@ -68,8 +68,8 @@ class PrestoEngine(PrestoCommandsMixin, SQLAlchemyEngine):
         })
         super().init(sql_alchemy_conf)
         self.conf = conf.with_fallback(PrestoEngine.DEFAULT_CONFIG)
-        self._default_cluster_name = \
-            self.conf.get_string(PrestoEngine.DEFAULT_CLUSTER_NAME_KEY)
+        self._default_catalog_name = \
+            self.conf.get_string(PrestoEngine.DEFAULT_CATALOG_NAME_KEY)
         self._database = self.conf.get_string(PrestoEngine.DATABASE_KEY)
         self._extract_iter = None
 

--- a/metaframe/example/sample_build_script.py
+++ b/metaframe/example/sample_build_script.py
@@ -14,7 +14,7 @@ conf = ConfigFactory.from_dict({
     'extractor.presto_loop.is_stats_enabled': False,
     'extractor.presto_loop.is_analyze_enabled': False,
     'extractor.presto_loop.database': None,
-    'extractor.presto_loop.cluster': None,
+    'extractor.presto_loop.catalog': None,
     'extractor.presto_loop.included_schemas': None,
     'extractor.presto_loop.excluded_schemas': None,
     'loader.metaframe.database_name': 'presto-test',

--- a/metaframe/extractor/amundsen_neo4j_metadata_extractor.py
+++ b/metaframe/extractor/amundsen_neo4j_metadata_extractor.py
@@ -151,7 +151,7 @@ class AmundsenNeo4jMetadataExtractor(Neo4jExtractor):
 
                 yield TableMetadata(
                     database=result['database'],
-                    cluster=result['cluster'],
+                    catalog=result['cluster'],
                     schema=result['schema'],
                     name=result['name'],
                     description=result['description'],

--- a/metaframe/extractor/bigquery_metadata_extractor.py
+++ b/metaframe/extractor/bigquery_metadata_extractor.py
@@ -80,7 +80,7 @@ class BigQueryMetadataExtractor(BaseBigQueryExtractor):
 
                 table_meta = TableMetadata(
                     database='bigquery',
-                    cluster=tableRef['projectId'],
+                    catalog=tableRef['projectId'],
                     schema=tableRef['datasetId'],
                     name=table_id,
                     description=table.get('description', ''),

--- a/metaframe/extractor/presto_loop_extractor.py
+++ b/metaframe/extractor/presto_loop_extractor.py
@@ -29,7 +29,7 @@ class PrestoLoopExtractor(PrestoEngine):
     CONN_STRING_KEY = 'conn_string'
     EXCLUDED_SCHEMAS_KEY = 'excluded_schemas'
     INCLUDED_SCHEMAS_KEY = 'included_schemas'
-    CLUSTER_KEY = 'cluster'
+    CATALOG_KEY = 'catalog'
     DATABASE_KEY = 'database'
     IS_FULL_EXTRACTION_ENABLED_KEY = 'is_full_extraction_enabled'
     IS_WATERMARK_ENABLED_KEY = 'is_watermark_enabled'
@@ -42,7 +42,7 @@ class PrestoLoopExtractor(PrestoEngine):
         CONN_STRING_KEY: None,
         EXCLUDED_SCHEMAS_KEY: None,
         INCLUDED_SCHEMAS_KEY: None,
-        CLUSTER_KEY: None,
+        CATALOG_KEY: None,
         DATABASE_KEY: 'presto',
         IS_FULL_EXTRACTION_ENABLED_KEY: False,
         IS_WATERMARK_ENABLED_KEY: False,
@@ -55,7 +55,7 @@ class PrestoLoopExtractor(PrestoEngine):
     def init(self, conf):
         super().init(conf)
         self.conf = conf.with_fallback(self.DEFAULT_CONFIG)
-        self._cluster = self.conf.get(PrestoLoopExtractor.CLUSTER_KEY)
+        self._catalog = self.conf.get(PrestoLoopExtractor.CATALOG_KEY)
         self._database = self.conf.get_string(PrestoLoopExtractor.DATABASE_KEY)
 
         self._extract_iter = None
@@ -65,7 +65,7 @@ class PrestoLoopExtractor(PrestoEngine):
             self.conf.get(PrestoLoopExtractor.INCLUDED_SCHEMAS_KEY) or []
 
         self._sql_stmt_schemas = \
-            ' in '.join(filter(None, ['show schemas', self._cluster]))
+            ' in '.join(filter(None, ['show schemas', self._catalog]))
         self._is_table_metadata_enabled = \
             self.conf.get(PrestoLoopExtractor.IS_TABLE_METADATA_ENABLED_KEY)
         self._is_stats_enabled = \
@@ -97,7 +97,7 @@ class PrestoLoopExtractor(PrestoEngine):
                     (schema in self._included_schemas)
                     or not self._included_schemas):
                 full_schema_address = \
-                    '.'.join(filter(None, [self._cluster, schema]))
+                    '.'.join(filter(None, [self._catalog, schema]))
                 tables = list(
                     self.execute(
                         'show tables in {}'
@@ -113,7 +113,7 @@ class PrestoLoopExtractor(PrestoEngine):
                     table = table_row[0]
                     file_name = get_table_file_path_base(
                         database=self._database,
-                        cluster=self._cluster,
+                        catalog=self._catalog,
                         schema=schema,
                         table=table,
                     )
@@ -125,17 +125,17 @@ class PrestoLoopExtractor(PrestoEngine):
                                 self.get_table_metadata(
                                     schema,
                                     table,
-                                    cluster=self._cluster,
+                                    catalog=self._catalog,
                                     is_view_query_enabled
                                         =self._is_view_query_enabled)
                             yield table_metadata
 
                         if self._is_analyze_enabled:
-                            self.get_analyze(schema, table, self._cluster)
+                            self.get_analyze(schema, table, self._catalog)
 
                         if self._is_stats_enabled:
                             stats_generator = \
-                                self.get_stats(schema, table, self._cluster)
+                                self.get_stats(schema, table, self._catalog)
                             yield from stats_generator
                     else:
                         LOGGER.info(

--- a/metaframe/extractor/snowflake_metadata_extractor.py
+++ b/metaframe/extractor/snowflake_metadata_extractor.py
@@ -33,15 +33,15 @@ class SnowflakeMetadataExtractor(Extractor):
         lower(c.data_type) AS col_type,
         lower(c.ordinal_position) AS col_sort_order,
         lower('{database}') AS database,
-        lower(c.table_catalog) AS cluster,
+        lower(c.table_catalog) AS catalog,
         lower(c.table_schema) AS schema,
         lower(c.table_name) AS name,
         t.comment AS description,
         decode(lower(t.table_type), 'view', 'true', 'false') AS is_view
     FROM
-        {cluster}.INFORMATION_SCHEMA.COLUMNS AS c
+        {catalog}.INFORMATION_SCHEMA.COLUMNS AS c
     LEFT JOIN
-        {cluster}.INFORMATION_SCHEMA.TABLES t
+        {catalog}.INFORMATION_SCHEMA.TABLES t
             ON c.TABLE_NAME = t.TABLE_NAME
             AND c.TABLE_SCHEMA = t.TABLE_SCHEMA
     {where_clause_suffix};
@@ -49,23 +49,23 @@ class SnowflakeMetadataExtractor(Extractor):
 
     WHERE_CLAUSE_SUFFIX_KEY = 'where_clause_suffix'
     DATABASE_KEY = 'database'
-    CLUSTER_KEY = 'cluster'
+    CATALOG_KEY = 'catalog'
 
     DEFAULT_CONFIG = ConfigFactory.from_dict({
         WHERE_CLAUSE_SUFFIX_KEY: '',
         DATABASE_KEY: 'snowflake',
-        CLUSTER_KEY: 'master',
+        CATALOG_KEY: 'master',
     })
 
     def init(self, conf: ConfigTree) -> None:
         self.conf = conf.with_fallback(
             SnowflakeMetadataExtractor.DEFAULT_CONFIG)
-        self._database = conf.get_string(SnowflakeMetadataExtractor.DATABASE_KEY)
-        self._cluster = '{}'.format(conf.get_string(SnowflakeMetadataExtractor.CLUSTER_KEY))
+        self._database = self.conf.get_string(SnowflakeMetadataExtractor.DATABASE_KEY)
+        self._catalog = '{}'.format(self.conf.get_string(SnowflakeMetadataExtractor.CATALOG_KEY))
 
         self.sql_stmt = SnowflakeMetadataExtractor.SQL_STATEMENT.format(
             where_clause_suffix=self.conf.get_string('where_clause_suffix'),
-            cluster=self._cluster,
+            catalog=self._catalog,
             database=self._database
         )
 
@@ -109,7 +109,7 @@ class SnowflakeMetadataExtractor(Extractor):
 
             yield TableMetadata(
                     database=self._database,
-                    cluster=last_row['cluster'],
+                    catalog=last_row['catalog'],
                     schema=last_row['schema'],
                     name=last_row['name'],
                     description=unidecode(last_row['description']) if last_row['description'] else None,

--- a/metaframe/loader/metaframe_loader.py
+++ b/metaframe/loader/metaframe_loader.py
@@ -34,7 +34,7 @@ class MetaframeLoader(Loader):
 
         table_file_path_base = get_table_file_path_base(
             database=self.database_name or record.database,
-            cluster=record.cluster,
+            catalog=record.catalog,
             schema=record.schema,
             table=record.name,
             base_directory=self.conf.get('base_directory')

--- a/metaframe/models/connection_config.py
+++ b/metaframe/models/connection_config.py
@@ -9,7 +9,7 @@ class ConnectionConfigSchema(object):
             username: Optional[str] = None,
             password: Optional[str] = None,
             name: Optional[str] = None,
-            cluster: Optional[str] = None,
+            catalog: Optional[str] = None,
             included_schemas: List = [],
             excluded_schemas: List = [],
             included_keys: Optional[List[str]] = None,
@@ -31,7 +31,7 @@ class ConnectionConfigSchema(object):
         self.username = username
         self.password = password
         self.name = name
-        self.cluster = cluster
+        self.catalog = catalog
         self.included_schemas = included_schemas
         self.excluded_schemas = excluded_schemas
         self.included_keys = included_keys

--- a/metaframe/models/presto_watermark.py
+++ b/metaframe/models/presto_watermark.py
@@ -9,7 +9,7 @@ class PrestoWatermark(object):
     Table watermark result model.
     Each instance represents one row of table watermark result.
     """
-    KEY_FORMAT = '{database}://{cluster}.{schema}' \
+    KEY_FORMAT = '{database}://{catalog}.{schema}' \
                  '/{table}/{part_type}/'
 
     def __init__(
@@ -19,7 +19,7 @@ class PrestoWatermark(object):
             table_name: str,
             parts: list,
             part_type: str = 'high_watermark',
-            cluster: str = 'gold',
+            catalog: str = 'gold',
             ) -> None:
         self.database = database.lower()
         self.schema = schema.lower()
@@ -28,27 +28,27 @@ class PrestoWatermark(object):
         # currently we don't consider nested partitions
         self.parts = parts
         self.part_type = part_type.lower()
-        self.cluster = cluster.lower()
+        self.catalog = catalog.lower()
 
     def get_watermark_model_key(self) -> str:
         return PrestoWatermark.KEY_FORMAT.format(
             database=self.database,
-            cluster=self.cluster,
+            catalog=self.catalog,
             schema=self.schema,
             table=self.table,
             part_type=self.part_type)
 
     def get_metadata_model_key(self) -> str:
-        return '{database}://{cluster}.{schema}/{table}'.format(
+        return '{database}://{catalog}.{schema}/{table}'.format(
             database=self.database,
-            cluster=self.cluster,
+            catalog=self.catalog,
             schema=self.schema,
             table=self.table)
 
     def get_col_key(self, col: str) -> str:
         return ColumnMetadata.COLUMN_KEY_FORMAT.format(
             db=self.database,
-            cluster=self.cluster,
+            catalog=self.catalog,
             schema=self.schema,
             tbl=self.table,
             col=col)

--- a/metaframe/transformer/markdown_transformer.py
+++ b/metaframe/transformer/markdown_transformer.py
@@ -14,7 +14,7 @@ class MarkdownTransformer(Transformer):
 
     HEADER_TEMPLATE = '{schema}.{name} {view_statement}'
     SUBHEADER_TEMPLATE = \
-        'Database: {database} | Cluster: {cluster}'
+        'Database: {database} | Cluster: {catalog}'
     DESCRIPTION_TEMPLATE = textwrap.dedent("""    # Description
     {description}\n
     """)
@@ -34,7 +34,7 @@ class MarkdownTransformer(Transformer):
             return
 
         database = record.database
-        cluster = record.cluster
+        catalog = record.catalog
         schema = record.schema
         table_name = record.name
         view_statement = '[view]' if record.is_view else ''
@@ -44,7 +44,7 @@ class MarkdownTransformer(Transformer):
 
         markdown_blob = self.format_templates(
             database=database,
-            cluster=cluster,
+            catalog=catalog,
             schema=schema,
             table_name=table_name,
             view_statement=view_statement,
@@ -53,7 +53,7 @@ class MarkdownTransformer(Transformer):
 
         return metadata_model_metaframe.TableMetadata(
             database=database,
-            cluster=cluster,
+            catalog=catalog,
             schema=schema,
             name=table_name,
             markdown_blob=markdown_blob,
@@ -108,7 +108,7 @@ class MarkdownTransformer(Transformer):
     def format_templates(
             self,
             database,
-            cluster,
+            catalog,
             schema,
             table_name,
             view_statement,
@@ -128,7 +128,7 @@ class MarkdownTransformer(Transformer):
                 2)
         subheader = MarkdownTransformer.SUBHEADER_TEMPLATE.format(
             database=database,
-            cluster=cluster,
+            catalog=catalog,
         )
         if description is not None:
             description_statement = \

--- a/metaframe/utils/__init__.py
+++ b/metaframe/utils/__init__.py
@@ -1,22 +1,22 @@
 import os
 from pathlib import Path
 
-TABLE_RELATIVE_FILE_PATH = '{database}/{cluster}.{schema}.{table}'
+TABLE_RELATIVE_FILE_PATH = '{database}/{catalog}.{schema}.{table}'
 CLUSTERLESS_TABLE_RELATIVE_FILE_PATH = '{database}/{schema}.{table}'
 
 
 def get_table_file_path_base(
         database,
-        cluster,
+        catalog,
         schema,
         table,
         base_directory=os.path.join(Path.home(), '.metaframe/metadata/')
         ):
 
-    if cluster is not None:
+    if catalog is not None:
         relative_file_path = TABLE_RELATIVE_FILE_PATH.format(
             database=database,
-            cluster=cluster,
+            catalog=catalog,
             schema=schema,
             table=table
         )

--- a/metaframe/utils/extractor_wrappers.py
+++ b/metaframe/utils/extractor_wrappers.py
@@ -57,7 +57,7 @@ def configure_presto_extractor(
         '{}.is_stats_enabled'.format(scope): False,
         '{}.is_analyze_enabled'.format(scope): False,
         '{}.database'.format(scope): connection.name,
-        '{}.cluster'.format(scope): connection.cluster,
+        '{}.catalog'.format(scope): connection.catalog,
         '{}.included_schemas'.format(scope): connection.included_schemas,
         '{}.excluded_schemas'.format(scope): connection.excluded_schemas,
     })
@@ -100,7 +100,7 @@ def configure_snowflake_extractor(connection: ConnectionConfigSchema):
     conf = ConfigFactory.from_dict({
         conn_string_key: conn_string,
         '{}.database'.format(scope): connection.name,
-        '{}.cluster'.format(scope): connection.cluster,
+        '{}.catalog'.format(scope): connection.catalog,
     })
 
     return extractor, conf

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ DEFAULT_DIRECTORY_NAME = '.metaframe'
 
 setuptools.setup(
     name='metaframe-databuilder',
-    version='0.0.0',
+    version='0.0.0a31',
     author='Robert Yi',
     author_email='robert@ryi.me',
     description="A pared-down metadata ETL library.",

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ DEFAULT_DIRECTORY_NAME = '.metaframe'
 
 setuptools.setup(
     name='metaframe-databuilder',
-    version='0.0.0a30',
+    version='0.0.0',
     author='Robert Yi',
     author_email='robert@ryi.me',
     description="A pared-down metadata ETL library.",

--- a/tests/unit/engine/test_presto_engine.py
+++ b/tests/unit/engine/test_presto_engine.py
@@ -10,13 +10,13 @@ from metaframe.models.table_metadata import ColumnMetadata, TableMetadata
 
 MOCK_CONNECTION_NAME = 'TEST_CONNECTION'
 MOCK_DATABASE_NAME = 'mock_database'
-MOCK_CLUSTER_NAME = 'mock_cluster'
+MOCK_CATALOG_NAME = 'mock_catalog'
 MOCK_SCHEMA_NAME = 'mock_schema'
 MOCK_TABLE_NAME = 'mock_table'
 MOCK_COLUMN_RESULT = ('ds', 'varchar(64)', 'partition key', '')
 MOCK_COLUMN_RESULT = ('ds', 'varchar(64)', 'partition key', '')
 MOCK_INFORMATION_SCHEMA_RESULT_1 = {
-    'catalog': MOCK_CLUSTER_NAME,
+    'catalog': MOCK_CATALOG_NAME,
     'schema': MOCK_SCHEMA_NAME,
     'name': MOCK_TABLE_NAME,
     'description': None,
@@ -28,7 +28,7 @@ MOCK_INFORMATION_SCHEMA_RESULT_1 = {
     'is_view': '0',
 }
 MOCK_INFORMATION_SCHEMA_RESULT_2 = {
-    'catalog': MOCK_CLUSTER_NAME,
+    'catalog': MOCK_CATALOG_NAME,
     'schema': MOCK_SCHEMA_NAME,
     'name': MOCK_TABLE_NAME,
     'description': None,
@@ -64,7 +64,7 @@ class TestPrestoEngine(unittest.TestCase):
         config_dict = {
             PrestoEngine.CONN_STRING_KEY: MOCK_CONNECTION_NAME,
             PrestoEngine.DATABASE_KEY: MOCK_DATABASE_NAME,
-            PrestoEngine.DEFAULT_CLUSTER_NAME_KEY: MOCK_CLUSTER_NAME
+            PrestoEngine.DEFAULT_CATALOG_NAME_KEY: MOCK_CATALOG_NAME
         }
         self.conf = ConfigFactory.from_dict(config_dict)
         self.engine = PrestoEngine()
@@ -78,7 +78,7 @@ class TestPrestoEngine(unittest.TestCase):
 
         expected = TableMetadata(
                 database=MOCK_DATABASE_NAME,
-                cluster=MOCK_CLUSTER_NAME,
+                catalog=MOCK_CATALOG_NAME,
                 schema=MOCK_SCHEMA_NAME,
                 name=MOCK_TABLE_NAME,
                 columns=[
@@ -99,7 +99,7 @@ class TestPrestoEngine(unittest.TestCase):
                 is_view=bool(MOCK_INFORMATION_SCHEMA_RESULT_1['is_view']),
         )
         results = self.engine.get_all_table_metadata_from_information_schema(
-            cluster=MOCK_CLUSTER_NAME)
+            catalog=MOCK_CATALOG_NAME)
         result = next(results)
         self.maxDiff = None
         self.assertEqual(result.__repr__(), expected.__repr__())

--- a/tests/unit/extractor/test_presto_loop_extractor.py
+++ b/tests/unit/extractor/test_presto_loop_extractor.py
@@ -68,7 +68,7 @@ class TestPrestoLoopExtractor(unittest.TestCase):
             else False
         expected = TableMetadata(
                 database=extractor._database,
-                cluster=None,
+                catalog=None,
                 schema=MOCK_SCHEMA_NAME,
                 name=MOCK_TABLE_NAME,
                 columns=[ColumnMetadata(

--- a/tests/unit/extractor/test_snowflake_metadata_extractor.py
+++ b/tests/unit/extractor/test_snowflake_metadata_extractor.py
@@ -1,0 +1,273 @@
+import logging
+import unittest
+
+from mock import patch, MagicMock
+from pyhocon import ConfigFactory
+from typing import Any, Dict  # noqa: F401
+
+from metaframe.extractor.snowflake_metadata_extractor import SnowflakeMetadataExtractor
+from databuilder.extractor.sql_alchemy_extractor import SQLAlchemyExtractor
+from metaframe.models.table_metadata import TableMetadata, ColumnMetadata
+
+
+class TestSnowflakeMetadataExtractor(unittest.TestCase):
+    def setUp(self):
+        # type: () -> None
+        logging.basicConfig(level=logging.INFO)
+
+        config_dict = {
+            'extractor.sqlalchemy.{}'.format(SQLAlchemyExtractor.CONN_STRING):
+            'TEST_CONNECTION',
+            SnowflakeMetadataExtractor.CATALOG_KEY: 'MY_CATALOG',
+            SnowflakeMetadataExtractor.DATABASE_KEY: 'prod'
+        }
+        self.conf = ConfigFactory.from_dict(config_dict)
+
+    def test_extraction_with_empty_query_result(self):
+        # type: () -> None
+        """
+        Test Extraction with empty result from query
+        """
+        with patch.object(SQLAlchemyExtractor, '_get_connection'):
+            extractor = SnowflakeMetadataExtractor()
+            extractor.init(self.conf)
+
+            results = extractor.extract()
+            self.assertEqual(results, None)
+
+    def test_extraction_with_single_result(self):
+        # type: () -> None
+        with patch.object(SQLAlchemyExtractor, '_get_connection') as mock_connection:
+            connection = MagicMock()
+            mock_connection.return_value = connection
+            sql_execute = MagicMock()
+            connection.execute = sql_execute
+            table = {'schema': 'test_schema',
+                     'name': 'test_table',
+                     'description': 'a table for testing',
+                     'catalog':
+                     self.conf[SnowflakeMetadataExtractor.CATALOG_KEY],
+                     'is_view': 'false'
+                     }
+
+            sql_execute.return_value = [
+                self._union(
+                    {'col_name': 'col_id1',
+                     'col_type': 'number',
+                     'col_description': 'description of id1',
+                     'col_sort_order': 0}, table),
+                self._union(
+                    {'col_name': 'col_id2',
+                     'col_type': 'number',
+                     'col_description': 'description of id2',
+                     'col_sort_order': 1}, table),
+                self._union(
+                    {'col_name': 'is_active',
+                     'col_type': 'boolean',
+                     'col_description': None,
+                     'col_sort_order': 2}, table),
+                self._union(
+                    {'col_name': 'source',
+                     'col_type': 'varchar',
+                     'col_description': 'description of source',
+                     'col_sort_order': 3}, table),
+                self._union(
+                    {'col_name': 'etl_created_at',
+                     'col_type': 'timestamp_ltz',
+                     'col_description': 'description of etl_created_at',
+                     'col_sort_order': 4}, table),
+                self._union(
+                    {'col_name': 'ds',
+                     'col_type': 'varchar',
+                     'col_description': None,
+                     'col_sort_order': 5}, table)
+            ]
+
+            extractor = SnowflakeMetadataExtractor()
+            extractor.init(self.conf)
+            actual = extractor.extract()
+            expected = TableMetadata('prod', 'MY_CATALOG', 'test_schema', 'test_table', 'a table for testing',
+                                     [ColumnMetadata('col_id1', 'description of id1', 'number', 0),
+                                      ColumnMetadata('col_id2', 'description of id2', 'number', 1),
+                                      ColumnMetadata('is_active', None, 'boolean', 2),
+                                      ColumnMetadata('source', 'description of source', 'varchar', 3),
+                                      ColumnMetadata('etl_created_at', 'description of etl_created_at',
+                                                     'timestamp_ltz', 4),
+                                      ColumnMetadata('ds', None, 'varchar', 5)])
+
+            self.assertEqual(expected.__repr__(), actual.__repr__())
+            self.assertIsNone(extractor.extract())
+
+    def test_extraction_with_multiple_result(self):
+        # type: () -> None
+        with patch.object(SQLAlchemyExtractor, '_get_connection') as mock_connection:
+            connection = MagicMock()
+            mock_connection.return_value = connection
+            sql_execute = MagicMock()
+            connection.execute = sql_execute
+            table = {'schema': 'test_schema1',
+                     'name': 'test_table1',
+                     'description': 'test table 1',
+                     'catalog':
+                     self.conf[SnowflakeMetadataExtractor.CATALOG_KEY],
+                     'is_view': 'nottrue'
+                     }
+
+            table1 = {'schema': 'test_schema1',
+                      'name': 'test_table2',
+                      'description': 'test table 2',
+                      'catalog':
+                      self.conf[SnowflakeMetadataExtractor.CATALOG_KEY],
+                      'is_view': 'false'
+                      }
+
+            table2 = {'schema': 'test_schema2',
+                      'name': 'test_table3',
+                      'description': 'test table 3',
+                      'catalog':
+                      self.conf[SnowflakeMetadataExtractor.CATALOG_KEY],
+                      'is_view': 'true'
+                      }
+
+            sql_execute.return_value = [
+                self._union(
+                    {'col_name': 'col_id1',
+                     'col_type': 'number',
+                     'col_description': 'description of col_id1',
+                     'col_sort_order': 0}, table),
+                self._union(
+                    {'col_name': 'col_id2',
+                     'col_type': 'number',
+                     'col_description': 'description of col_id2',
+                     'col_sort_order': 1}, table),
+                self._union(
+                    {'col_name': 'is_active',
+                     'col_type': 'boolean',
+                     'col_description': None,
+                     'col_sort_order': 2}, table),
+                self._union(
+                    {'col_name': 'source',
+                     'col_type': 'varchar',
+                     'col_description': 'description of source',
+                     'col_sort_order': 3}, table),
+                self._union(
+                    {'col_name': 'etl_created_at',
+                     'col_type': 'timestamp_ltz',
+                     'col_description': 'description of etl_created_at',
+                     'col_sort_order': 4}, table),
+                self._union(
+                    {'col_name': 'ds',
+                     'col_type': 'varchar',
+                     'col_description': None,
+                     'col_sort_order': 5}, table),
+                self._union(
+                    {'col_name': 'col_name',
+                     'col_type': 'varchar',
+                     'col_description': 'description of col_name',
+                     'col_sort_order': 0}, table1),
+                self._union(
+                    {'col_name': 'col_name2',
+                     'col_type': 'varchar',
+                     'col_description': 'description of col_name2',
+                     'col_sort_order': 1}, table1),
+                self._union(
+                    {'col_name': 'col_id3',
+                     'col_type': 'varchar',
+                     'col_description': 'description of col_id3',
+                     'col_sort_order': 0}, table2),
+                self._union(
+                    {'col_name': 'col_name3',
+                     'col_type': 'varchar',
+                     'col_description': 'description of col_name3',
+                     'col_sort_order': 1}, table2)
+            ]
+
+            extractor = SnowflakeMetadataExtractor()
+            extractor.init(self.conf)
+
+            expected = TableMetadata('prod',
+                                     self.conf[SnowflakeMetadataExtractor.CATALOG_KEY],
+                                     'test_schema1', 'test_table1', 'test table 1',
+                                     [ColumnMetadata('col_id1', 'description of col_id1', 'number', 0),
+                                      ColumnMetadata('col_id2', 'description of col_id2', 'number', 1),
+                                      ColumnMetadata('is_active', None, 'boolean', 2),
+                                      ColumnMetadata('source', 'description of source', 'varchar', 3),
+                                      ColumnMetadata('etl_created_at', 'description of etl_created_at',
+                                                     'timestamp_ltz', 4),
+                                      ColumnMetadata('ds', None, 'varchar', 5)])
+            self.assertEqual(expected.__repr__(), extractor.extract().__repr__())
+
+            expected = TableMetadata('prod',
+                                     self.conf[SnowflakeMetadataExtractor.CATALOG_KEY],
+                                     'test_schema1', 'test_table2', 'test table 2',
+                                     [ColumnMetadata('col_name', 'description of col_name', 'varchar', 0),
+                                      ColumnMetadata('col_name2', 'description of col_name2', 'varchar', 1)])
+            self.assertEqual(expected.__repr__(), extractor.extract().__repr__())
+
+            expected = TableMetadata('prod',
+                                     self.conf[SnowflakeMetadataExtractor.CATALOG_KEY],
+                                     'test_schema2', 'test_table3', 'test table 3',
+                                     [ColumnMetadata('col_id3', 'description of col_id3', 'varchar', 0),
+                                      ColumnMetadata('col_name3', 'description of col_name3',
+                                                     'varchar', 1)],
+                                     True)
+            self.assertEqual(expected.__repr__(), extractor.extract().__repr__())
+
+            self.assertIsNone(extractor.extract())
+            self.assertIsNone(extractor.extract())
+
+    def _union(self, target, extra):
+        # type: (Dict[Any, Any], Dict[Any, Any]) -> Dict[Any, Any]
+        target.update(extra)
+        return target
+
+
+class TestSnowflakeMetadataExtractorWithWhereClause(unittest.TestCase):
+    def setUp(self):
+        # type: () -> None
+        logging.basicConfig(level=logging.INFO)
+        self.where_clause_suffix = """
+        where table_schema in ('public') and table_name = 'movies'
+        """
+
+        config_dict = {
+            SnowflakeMetadataExtractor.WHERE_CLAUSE_SUFFIX_KEY: self.where_clause_suffix,
+            'extractor.sqlalchemy.{}'.format(SQLAlchemyExtractor.CONN_STRING):
+                'TEST_CONNECTION'
+        }
+        self.conf = ConfigFactory.from_dict(config_dict)
+
+    def test_sql_statement(self):
+        # type: () -> None
+        """
+        Test Extraction with empty result from query
+        """
+        with patch.object(SQLAlchemyExtractor, '_get_connection'):
+            extractor = SnowflakeMetadataExtractor()
+            extractor.init(self.conf)
+            self.assertTrue(self.where_clause_suffix in extractor.sql_stmt)
+
+
+class TestSnowflakeMetadataExtractorDefaultDatabaseKey(unittest.TestCase):
+    def setUp(self):
+        # type: () -> None
+        logging.basicConfig(level=logging.INFO)
+        self.catalog_key = "mock_catalog"
+        self.database_key = "mock_database"
+
+        config_dict = {
+            SnowflakeMetadataExtractor.CATALOG_KEY: self.catalog_key,
+            'extractor.sqlalchemy.{}'.format(SQLAlchemyExtractor.CONN_STRING):
+                'TEST_CONNECTION'
+        }
+        self.conf = ConfigFactory.from_dict(config_dict)
+
+    def test_sql_statement(self):
+        # type: () -> None
+        """
+        Test Extraction with empty result from query
+        """
+        with patch.object(SQLAlchemyExtractor, '_get_connection'):
+            extractor = SnowflakeMetadataExtractor()
+            extractor.init(self.conf)
+            self.assertTrue(self.catalog_key in extractor.sql_stmt)

--- a/tests/unit/loader/test_metaframe_loader.py
+++ b/tests/unit/loader/test_metaframe_loader.py
@@ -15,10 +15,10 @@ class TestMetaframeLoader(unittest.TestCase):
             'base_directory': './.test_artifacts',
             })
 
-    def test_load_no_cluster(self):
+    def test_load_no_catalog(self):
         record = TableMetadata(
             database='mock_database',
-            cluster=None,
+            catalog=None,
             schema='mock_schema',
             name='mock_table',
             markdown_blob='Test',
@@ -35,10 +35,10 @@ class TestMetaframeLoader(unittest.TestCase):
 
         self.assertEqual(written_record, record.markdown_blob)
 
-    def test_load_cluster_specified(self):
+    def test_load_catalog_specified(self):
         record = TableMetadata(
             database='mock_database',
-            cluster='mock_cluster',
+            catalog='mock_catalog',
             schema='mock_schema',
             name='mock_table',
             markdown_blob='Test',
@@ -50,7 +50,7 @@ class TestMetaframeLoader(unittest.TestCase):
         loader.close()
         file_path = \
             './.test_artifacts/' + \
-            'mock_database/mock_cluster.mock_schema.mock_table.md'
+            'mock_database/mock_catalog.mock_schema.mock_table.md'
         with open(file_path, 'r') as f:
             written_record = f.read()
         print(written_record)

--- a/tests/unit/transformer/test_markdown_transformer.py
+++ b/tests/unit/transformer/test_markdown_transformer.py
@@ -9,7 +9,7 @@ from metaframe.transformer.markdown_transformer import MarkdownTransformer
 
 
 DATABASE = 'mock_database'
-CLUSTER = 'mock_cluster'
+CATALOG = 'mock_catalog'
 SCHEMA = 'mock_schema'
 TABLE = 'mock_table'
 COLUMN = 'mock_column'
@@ -34,14 +34,14 @@ class TestMetaframeLoader(unittest.TestCase):
         )
         record = TableMetadata(
             database=DATABASE,
-            cluster=CLUSTER,
+            catalog=CATALOG,
             schema=SCHEMA,
             name=TABLE,
             columns=[column]
         )
         components = [
             DATABASE,
-            CLUSTER,
+            CATALOG,
             SCHEMA,
             TABLE,
             COLUMN,


### PR DESCRIPTION
* Refactor all instances of `cluster` to `catalog`, since this appears to be the appropriate term for presto, snowflake, and `information_schema` entries. **This represents a substantial change in the connections.yaml syntax -- moving forward, `catalog` needs to be specified where `cluster` was previously specified.**
* Add snowflake tests.